### PR TITLE
Fix webguardian profile

### DIFF
--- a/profiles/webguardian.php
+++ b/profiles/webguardian.php
@@ -1,5 +1,5 @@
 <?php
-require '../db.php';
+
 $query = $conn->query("SELECT * FROM secret_word");
 $result = $query->fetch(PDO::FETCH_ASSOC);
 $secret_word = $result['secret_word'];


### PR DESCRIPTION
- The profile was not showing due to it requiring db.php file with incorrect file path

- Removed the line that required db.php with incorrect file as it is already being required by profile.php and the profile is included in profile.php so it has access to db variables already.